### PR TITLE
Update fluentd to version 1.10-1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 version.txt
+
+*.iml
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM fluent/fluentd:stable
+FROM fluent/fluentd:v1.10-1
+
+USER root
 
 RUN apk update \
     && apk add ruby-dev \
@@ -11,3 +13,5 @@ RUN apk update \
     && apk del build-base \
     && rm -rf /var/cache/apk/*
 COPY fluent.conf /fluentd/etc/fluent.conf
+
+USER fluent


### PR DESCRIPTION
This is the latest version available (edge).
The versioning of fluentd is a bit strange.
The documentation refers to either edge (which
probably is stable) or legacy.
Going with edge for now.